### PR TITLE
Add cache status indicator to all data-fetching screens

### DIFF
--- a/lib/Screens/Creditors_screen.dart
+++ b/lib/Screens/Creditors_screen.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import '../controllers/customerLedger_Controller.dart';
 import '../widget/animated_Dots_LoadingText.dart';
 import '../widget/custom_app_bar.dart';
+import '../widget/cache_status_indicator.dart';
 
 class CreditorsScreen extends StatefulWidget {
   const CreditorsScreen({super.key});
@@ -95,6 +96,7 @@ class _CreditorsScreen extends State<CreditorsScreen> {
               onChanged: (v) => searchQ.value = v,
             ),
           ),
+          const CacheStatusIndicator(),
 
           // ───── type filter chips ─────
           Padding(

--- a/lib/Screens/Debtors_screen.dart
+++ b/lib/Screens/Debtors_screen.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import '../controllers/customerLedger_Controller.dart';
 import '../widget/animated_Dots_LoadingText.dart';
 import '../widget/custom_app_bar.dart';
+import '../widget/cache_status_indicator.dart';
 
 class DebtorsScreen extends StatefulWidget {
   const DebtorsScreen({super.key});
@@ -95,6 +96,7 @@ class _DebtorsScreenState extends State<DebtorsScreen> {
               onChanged: (v) => searchQ.value = v,
             ),
           ),
+          const CacheStatusIndicator(),
 
           // ───── type filter chips ─────
           Padding(

--- a/lib/Screens/customer_ledger_screen.dart
+++ b/lib/Screens/customer_ledger_screen.dart
@@ -8,6 +8,7 @@ import '../controllers/customerLedger_Controller.dart';
 import '../model/allaccounts_model.dart';
 import '../widget/animated_Dots_LoadingText.dart';
 import '../widget/custom_app_bar.dart';
+import '../widget/cache_status_indicator.dart';
 
 class CustomerLedger_Screen extends StatefulWidget {
   const CustomerLedger_Screen({super.key});
@@ -92,6 +93,7 @@ class _CustomerLedger_ScreenState extends State<CustomerLedger_Screen> {
                   children: [
                     const SizedBox(height: 12),
                     _autocomplete(names, context), // Pass context
+                    const CacheStatusIndicator(),
                     Expanded(
                       child: SingleChildScrollView(
                         controller: scrollCtrl,

--- a/lib/Screens/profit_screen.dart
+++ b/lib/Screens/profit_screen.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import '../controllers/profit_report_controller.dart';
 import '../widget/animated_Dots_LoadingText.dart';
 import '../widget/custom_app_bar.dart';
+import '../widget/cache_status_indicator.dart';
 import 'package:fl_chart/fl_chart.dart'; // Import fl_chart
 import 'dart:math'; // For random colors
 
@@ -58,6 +59,7 @@ class _ProfitReportScreenState extends State<ProfitReportScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 12),
             child: _buildSearchField(),
           ),
+          const CacheStatusIndicator(),
           const SizedBox(height: 10),
           Expanded(
             child: Obx(() {

--- a/lib/Screens/sales_screen.dart
+++ b/lib/Screens/sales_screen.dart
@@ -8,6 +8,7 @@ import '../controllers/sales_controller.dart'; // Ensure SalesController is upda
 
 import '../widget/animated_Dots_LoadingText.dart';
 import '../widget/custom_app_bar.dart';
+import '../widget/cache_status_indicator.dart';
 
 class SalesScreen extends StatefulWidget {
   const SalesScreen({super.key});
@@ -159,6 +160,7 @@ class _SalesScreenState extends State<SalesScreen> with SingleTickerProviderStat
                       padding: const EdgeInsets.only(bottom: 100),
                       children: [
                         _filters(context),
+                        const CacheStatusIndicator(),
                         const SizedBox(height: 8),
                         Row(
                           children: [

--- a/lib/Screens/stock_Screens/Item_List_Screen.dart
+++ b/lib/Screens/stock_Screens/Item_List_Screen.dart
@@ -5,6 +5,7 @@ import '../../controllers/item_type_controller.dart';
 import '../../main.dart'; // routeObserver
 import '../../routes/routes.dart';
 import '../../widget/custom_app_bar.dart';
+import '../../widget/cache_status_indicator.dart';
 import '../../widget/rounded_search_field.dart';
 import 'item_batch_screen.dart';
 
@@ -132,6 +133,7 @@ class _ItemListScreenState extends State<ItemListScreen> with RouteAware {
               },
             ),
           ),
+          const CacheStatusIndicator(),
           Expanded(
             child: RefreshIndicator(
               // Use theme's primary color for refresh indicator

--- a/lib/Screens/stock_Screens/item_batch_screen.dart
+++ b/lib/Screens/stock_Screens/item_batch_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../controllers/item_type_controller.dart';
 import '../../widget/custom_app_bar.dart';
+import '../../widget/cache_status_indicator.dart';
 
 class ItemBatchScreen extends StatelessWidget {
   final String itemname;
@@ -116,19 +117,23 @@ class ItemBatchScreen extends StatelessWidget {
       appBar: CustomAppBar(
         title: Text('Batches for ItemCode $itemCode'),
       ),
-      body: Obx(() {
-        final batches = controller.itemDetailsByCode[itemCode] ?? [];
+      body: Column(
+        children: [
+          const CacheStatusIndicator(),
+          Expanded(
+            child: Obx(() {
+              final batches = controller.itemDetailsByCode[itemCode] ?? [];
 
-        if (batches.isEmpty) {
-          return Center(
-            child: Text(
-              'No batches found.',
-              style: TextStyle(color: onSurfaceColor), // Theme-aware text color
-            ),
-          );
-        }
+              if (batches.isEmpty) {
+                return Center(
+                  child: Text(
+                    'No batches found.',
+                    style: TextStyle(color: onSurfaceColor), // Theme-aware text color
+                  ),
+                );
+              }
 
-        return ListView.builder(
+              return ListView.builder(
           itemCount: batches.length,
           itemBuilder: (_, index) {
             final d = batches[index];
@@ -254,6 +259,9 @@ class ItemBatchScreen extends StatelessWidget {
           },
         );
       }),
+    ),
+        ],
+      ),
     );
   }
 }

--- a/lib/Screens/stock_Screens/item_type_screen.dart
+++ b/lib/Screens/stock_Screens/item_type_screen.dart
@@ -4,6 +4,7 @@ import '../../controllers/item_type_controller.dart';
 import '../../main.dart'; // Ensure this is correctly imported for routeObserver
 import '../../widget/animated_Dots_LoadingText.dart';
 import '../../widget/custom_app_bar.dart';
+import '../../widget/cache_status_indicator.dart';
 import '../../widget/refresh_indicator.dart'; // Assuming AppRefreshIndicator is here
 import '../../widget/rounded_search_field.dart'; // Assuming RoundedSearchField is here
 
@@ -83,6 +84,7 @@ class _ItemTypeScreenState extends State<ItemTypeScreen> with RouteAware {
               },
             ),
           ),
+          const CacheStatusIndicator(),
 
           Expanded(
             child: Obx(() {

--- a/lib/Screens/stock_report.dart
+++ b/lib/Screens/stock_report.dart
@@ -7,6 +7,7 @@ import '../controllers/stock_report_controller.dart';
 import '../widget/rounded_search_field.dart';
 import '../widget/animated_Dots_LoadingText.dart';
 import '../widget/custom_app_bar.dart';
+import '../widget/cache_status_indicator.dart';
 import 'dart:developer'; // Import for the log function
 
 class StockScreen extends StatefulWidget {
@@ -54,6 +55,7 @@ class _StockScreenState extends State<StockScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
             child: _buildSortOptions(context),
           ),
+          const CacheStatusIndicator(),
           const SizedBox(height: 10),
           Expanded( // Expanded takes the remaining vertical space
             child: Obx(() {

--- a/lib/widget/cache_status_indicator.dart
+++ b/lib/widget/cache_status_indicator.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import '../services/CsvDataServices.dart';
+
+class CacheStatusIndicator extends StatelessWidget {
+  final bool showTimestamp;
+  final double? width;
+  final EdgeInsetsGeometry? margin;
+
+  const CacheStatusIndicator({
+    super.key,
+    this.showTimestamp = true,
+    this.width,
+    this.margin,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final csvService = Get.find<CsvDataService>();
+    final theme = Theme.of(context);
+    
+    return Obx(() {
+      final dataSource = csvService.lastDataSource.value;
+      final lastCacheTime = csvService.lastCacheTime.value;
+      final isFromCache = csvService.isDataFromCache.value;
+      
+      if (dataSource == 'Unknown') {
+        return const SizedBox.shrink();
+      }
+
+      final Color indicatorColor;
+      final IconData indicatorIcon;
+      final String statusText;
+
+      if (isFromCache) {
+        indicatorColor = theme.colorScheme.secondary;
+        indicatorIcon = Icons.cached;
+        statusText = 'Cached Data';
+      } else {
+        indicatorColor = theme.colorScheme.primary;
+        indicatorIcon = Icons.cloud_download;
+        statusText = 'Fresh Data';
+      }
+
+      return Container(
+        width: width,
+        margin: margin ?? const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: indicatorColor.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: indicatorColor.withOpacity(0.3),
+            width: 1,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              indicatorIcon,
+              size: 14,
+              color: indicatorColor,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              statusText,
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+                color: indicatorColor,
+              ),
+            ),
+            if (showTimestamp && lastCacheTime != null) ...[
+              const SizedBox(width: 4),
+              Text(
+                '•',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: indicatorColor.withOpacity(0.7),
+                ),
+              ),
+              const SizedBox(width: 4),
+              Text(
+                DateFormat('HH:mm').format(lastCacheTime),
+                style: TextStyle(
+                  fontSize: 10,
+                  color: indicatorColor.withOpacity(0.8),
+                ),
+              ),
+            ],
+          ],
+        ),
+      );
+    });
+  }
+}


### PR DESCRIPTION
Add a visual cache status indicator to all data-fetching screens.

This PR introduces a `CacheStatusIndicator` widget and integrates it across all screens that fetch data, providing users with immediate visual feedback on whether the displayed data is from the local cache or freshly downloaded from the network, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0ce188a-545d-467c-83b0-3e8abc34a439">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0ce188a-545d-467c-83b0-3e8abc34a439">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>